### PR TITLE
Add Golazon (open source football mnmlst website)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ A curated list of awesome [Riot.js](http://riotjs.com/) resources! The library i
   - [Hacker News](http://txchen.github.io/riot-hn/#news/1)
   - [Shopping cart](http://txchen.github.io/feplay/riot_flux/)
   - [Autocomplete](http://richardbondi.net/riot/)
+  - [Golazon - mnmlst soccer data](https://github.com/sobstel/golazon)
   
 ### Tools
 


### PR DESCRIPTION
It's a prototype (proof of concept) for extremely lightweight football (soccer) website.

Riot plays important role to make it happen. All static file weight ~26KB gzipped (and a lot of this space takes `superagent` lib which could be replaced with something smaller at some point, eg `fetch` polyfill).

More info: https://github.com/sobstel/golazon. Website is live: http://www.golazon.com/. It's non-profit hobby project.